### PR TITLE
[FEATURE] Prevent connection on driver initialization

### DIFF
--- a/Classes/Driver/FTPDriver.php
+++ b/Classes/Driver/FTPDriver.php
@@ -225,11 +225,17 @@ class FTPDriver extends \TYPO3\CMS\Core\Resource\Driver\AbstractHierarchicalFile
 		}
 
 		// Connect to FTP server.
-		try {
-			$this->ftpClient = GeneralUtility::makeInstance('AdGrafik\\FalFtp\\FTPClient\\FTP', $this->configuration)
-				 ->connect($this->configuration['username'], $this->configuration['password'], $this->configuration['ssl']);
-		} catch (\AdGrafik\FalFtp\FTPClient\Exception $exception) {
-			$this->addFlashMessage('FTP error: ' . $exception->getMessage());
+		$this->ftpClient = GeneralUtility::makeInstance('AdGrafik\\FalFtp\\FTPClient\\FTP', $this->configuration);
+		$registryObject = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Registry::class);
+		$storageIdentifier = 'sys_file_storage-' . $this->storageUid . '-' . sha1(serialize($this->configuration)) . '-fal_ftp-configuration-check';
+		$configurationChecked = $registryObject->get('fal_ftp', $storageIdentifier, 0);
+		if (!$configurationChecked) {
+			try {
+				$this->ftpClient->connect();
+				$registryObject->set('fal_ftp', $storageIdentifier, 1);
+			} catch (\AdGrafik\FalFtp\FTPClient\Exception $exception) {
+				$this->addFlashMessage('FTP error: ' . $exception->getMessage());
+			}
 		}
 	}
 

--- a/Classes/FTPClient/AbstractFTP.php
+++ b/Classes/FTPClient/AbstractFTP.php
@@ -71,6 +71,7 @@ abstract class AbstractFTP implements \AdGrafik\FalFtp\FTPClient\FTPInterface {
 	 * @return resource
 	 */
 	public function getStream() {
+		$this->connect();
 		return $this->stream;
 	}
 


### PR DESCRIPTION
Driver is initialized with every call to TYPO3. Even if no FTP resource
is included in the page, the connection gets initialized. This patch
changes the behavior, so the connection is only initialized if an action
needs the connection stream. Furthermore the connection is tested for
each configuration once to validate driver configuration.
