### PR TITLE
Fix statement in sanitizeFileName

### DIFF
--- a/Classes/Driver/FTPDriver.php
+++ b/Classes/Driver/FTPDriver.php
@@ -1035,7 +1035,7 @@ class FTPDriver extends AbstractHierarchicalFilesystemDriver {
 		}
 		// Strip trailing dots and return
 		$cleanFileName = preg_replace('/\\.*$/', '', $cleanFileName);
-		if (!$cleanFileName) {
+		if ($cleanFileName === false) {
 			throw new \TYPO3\CMS\Core\Resource\Exception\InvalidFileNameException(
 				'File name ' . $cleanFileName . ' is invalid.',
 				1320288991


### PR DESCRIPTION
Seems like sanitizeFileName() fal_ftp/Classes/Driver/FTPDriver.php can not handle filenames like '0', which is likely to happen when typo3 creates _processed folders dynamically.

I assume this part causes the trouble:
`
if (!$cleanFileName) {
			throw new \TYPO3\CMS\Core\Resource\Exception\InvalidFileNameException(
				'File name ' . $cleanFileName . ' is invalid.',
				1320288991
			);
		}
`